### PR TITLE
feat: add support TCP/TCMP frame

### DIFF
--- a/src/id3v2/frames.mjs
+++ b/src/id3v2/frames.mjs
@@ -577,6 +577,13 @@ export const WFED = {
   version: [3, 4]
 }
 
+export const TCMP = {
+  parse: parsers.textFrame,
+  validate: validators.textFrame,
+  write: writers.textFrame,
+  version: [3, 4]
+}
+
 export const TGID = {
   parse: parsers.win1251Frame,
   validate: validators.urlFrame,
@@ -976,6 +983,13 @@ export const POP = {
  *  Non-standard ID3v2.2 frames
  */
 export const GP1 = {
+  parse: parsers.textFrame,
+  validate: validators.textFrame,
+  write: writers.textFrame,
+  version: [2]
+}
+
+export const TCP = {
   parse: parsers.textFrame,
   validate: validators.textFrame,
   write: writers.textFrame,

--- a/types/id3v2/tags.d.ts
+++ b/types/id3v2/tags.d.ts
@@ -57,6 +57,7 @@ export interface MP3TagTagsV2Defined {
     GEO?: Array<frames.MP3TagGEOBFrame>;
     CNT?: frames.MP3TagTextFrame;
     POP?: Array<frames.MP3TagPOPMFrame>;
+    TCP?: frames.MP3TagTextFrame;
     GP1?: frames.MP3TagTextFrame;
     APIC?: Array<frames.MP3TagAPICFrame>;
     COMM?: Array<frames.MP3TagLangDescFrame>;
@@ -75,6 +76,7 @@ export interface MP3TagTagsV2Defined {
     SYTC?: frames.MP3TagSYTCFrame;
     TALB?: frames.MP3TagTextFrame;
     TBPM?: frames.MP3TagTextFrame;
+    TCMP?: frames.MP3TagTextFrame;
     TCOM?: frames.MP3TagTextFrame;
     TCON?: frames.MP3TagTextFrame;
     TCOP?: frames.MP3TagTextFrame;


### PR DESCRIPTION
 iTunes ( PS: and some other softwares like [navidrome ](https://www.navidrome.org/docs/faq/#-i-have-an-album-with-tracks-by-different-artists-why-is-it-broken-up-into-lots-of-separate-albums-each-with-their-own-artist) )uses this frame to indicate if the file is part of a compilation. To be noticed that it's an unofficial frame.

Check [iTunes Compilation Flag page on id3](https://id3.org/iTunes%20Compilation%20Flag) or [mp3tag's mapping](https://docs.mp3tag.de/mapping/#compilation) for a bit more information.