### PR TITLE
fix(v2.3): apply unsynchronisation at tag level per §5

### DIFF
--- a/src/id3v2/index.mjs
+++ b/src/id3v2/index.mjs
@@ -5,7 +5,7 @@ import { getHeaderFlags, getFrameFlags } from './flags.mjs'
 import * as frames from './frames.mjs'
 
 import {
-  setBit, decodeSynch, encodeSynch, synch, mergeBytes
+  setBit, decodeSynch, encodeSynch, synch, unsynch, mergeBytes
 } from '../utils/bytes.mjs'
 
 export function hasID3v2 (buffer) {
@@ -14,7 +14,7 @@ export function hasID3v2 (buffer) {
 }
 
 export function decode (buffer, tagOffset, parseUnsupported) {
-  const view = new BufferView(buffer, tagOffset)
+  let view = new BufferView(buffer, tagOffset)
   const version = view.getUint8(3, 2)
   const size = decodeSynch(view.getUint32(6))
   const flags = getHeaderFlags(view.getUint8(5), version[0])
@@ -25,9 +25,31 @@ export function decode (buffer, tagOffset, parseUnsupported) {
     throw new Error('Unknown ID3v2 major version')
   }
 
+  // ID3v2.2 §6.1 / ID3v2.3 §5: unsynchronisation is a TAG-level operation
+  // when the tag-level flag is set — the entire frame area after the
+  // 10-byte tag header is unsynchronised as one block. Un-unsynchronise
+  // it here before parsing any frames. For ID3v2.4 (§4.1.2) unsync moved
+  // to per-frame; the tag-level bit is only a hint and is honoured inside
+  // decodeFrame.
+  //
+  // After un-unsynchronisation the frame stream shrinks (each `$FF $00`
+  // pair collapses to `$FF`), so `frameLimit` tracks the real post-synch
+  // length rather than the unsynched `size` declared in the header.
+  let frameLimit = size
+  if ((version[0] === 2 || version[0] === 3) && flags.unsynchronisation) {
+    const raw = view.getUint8(10, size)
+    const synched = synch(Array.isArray(raw) ? raw : [raw])
+    const rebuilt = new Uint8Array(10 + synched.length)
+    const header = view.getUint8(0, 10)
+    rebuilt.set(Array.isArray(header) ? header : [header], 0)
+    rebuilt.set(synched, 10)
+    view = new BufferView(rebuilt)
+    frameLimit = synched.length
+  }
+
   const frameHeaderSize = version[0] === 2 ? 6 : 10
   let offset = 10
-  let limit = size
+  let limit = frameLimit
 
   const pushTag = (tag) => {
     const singleFrame = ['OWNE', 'MCDI', 'RVAD', 'SYTC', 'ETCO', 'PCNT']
@@ -52,9 +74,9 @@ export function decode (buffer, tagOffset, parseUnsupported) {
     }
   }
 
-  while (offset < size) {
+  while (offset - 10 < frameLimit) {
     const frameBytes = view.getUint8(offset, limit)
-    const frame = decodeFrame(frameBytes, { version, flags, parseUnsupported })
+    const frame = decodeFrame(frameBytes, { version, parseUnsupported })
     if (!frame) break
 
     offset += frame.size + frameHeaderSize
@@ -74,7 +96,7 @@ function decodeFrame (bytes, options) {
   if (view.getUint8(0) === 0x00) return false
 
   const frame = {}
-  const { version, flags, parseUnsupported } = options
+  const { version, parseUnsupported } = options
   const sizeByte = version[0] === 2 ? view.getUint24(3) : view.getUint32(4)
 
   frame.id = view.getUint8String(0, version[0] === 2 ? 3 : 4)
@@ -95,8 +117,15 @@ function decodeFrame (bytes, options) {
     dataLength -= 4
   }
 
-  let unsynchedData = flags.unsynchronisation
-  if (version === 4) unsynchedData = frame.flags.unsynchronisation
+  // Tag-level unsynchronisation for ID3v2.2 / ID3v2.3 has already been
+  // applied by `decode()` before frame parsing (v2.2 §6.1 / v2.3 §5), so
+  // at this point only the per-frame v2.4 unsync flag matters.
+  // Previously this compared `version === 4` where `version` is the
+  // `[major, revision]` array, making the check dead code — the fallback
+  // silently re-applied tag-level un-unsync per frame, which was
+  // accidentally correct only because the writer also unsynchronised
+  // frame bodies individually (non-compliant for v2.3).
+  const unsynchedData = version[0] === 4 && frame.flags.unsynchronisation
 
   if (unsynchedData) {
     const uint8 = view.getUint8(offset, dataLength)
@@ -147,12 +176,24 @@ export function validate (tags, strict, options) {
 }
 
 export function encode (tags, options) {
-  const { version, padding, unsynch, unsupported, encoding, encodingIndex } = options
+  const { version, padding, unsynch: unsyncRequested, unsupported, encoding, encodingIndex } = options
   const headerBytes = [0x49, 0x44, 0x33, version, 0]
   let flagsByte = 0
   const sizeView = new BufferView(4)
   const paddingBytes = new Uint8Array(padding)
-  const framesBytes = []
+  let framesBytes = []
+
+  // ID3v2.2 §6.1 / ID3v2.3 §5: unsynchronisation is a TAG-level operation;
+  // the entire concatenated frame stream (headers + bodies) is unsynched
+  // once, and the tag-level flag signals the reader to reverse it before
+  // frame parsing. Frame bodies must NOT be individually unsynchronised
+  // in v2.3 — doing so corrupts frame sizes and breaks any compliant
+  // reader that un-unsyncs at tag level.
+  //
+  // ID3v2.4 §4.1.2 moves unsync to per-frame, each with its own flag
+  // and a 4-byte DataLengthIndicator carrying the pre-unsync size.
+  const perFrameUnsync = unsyncRequested && version === 4
+  const tagLevelUnsync = unsyncRequested && version !== 4
 
   for (const id in tags) {
     const frameSpec = frames[id]
@@ -160,7 +201,7 @@ export function encode (tags, options) {
 
     if (!isSupported && !unsupported) continue
 
-    const writeOptions = { id, version, unsynch, encoding, encodingIndex }
+    const writeOptions = { id, version, unsynch: perFrameUnsync, encoding, encodingIndex }
     const bytes = !isSupported && unsupported
       ? frames.unsupported.write(tags[id], writeOptions)
       : frameSpec.write(tags[id], writeOptions)
@@ -168,7 +209,8 @@ export function encode (tags, options) {
     bytes.forEach(byte => framesBytes.push(byte))
   }
 
-  if (unsynch) flagsByte = setBit(flagsByte, 7)
+  if (tagLevelUnsync) framesBytes = unsynch(framesBytes)
+  if (unsyncRequested) flagsByte = setBit(flagsByte, 7)
   sizeView.setUint32(0, encodeSynch(framesBytes.length))
 
   return mergeBytes(

--- a/test/id3v2/index.cjs
+++ b/test/id3v2/index.cjs
@@ -233,6 +233,121 @@ describe('ID3v2', function () {
       ])
     })
 
+    it('v2.3 unsynchronisation is applied at tag level (§5)', function () {
+      // Regression test: previously the v2.3 writer unsynchronised each
+      // frame body individually AND set the tag-level unsync flag. That
+      // produced tags that were accidentally self-readable but violated
+      // ID3v2.3 §5 — which defines unsync as a TAG-level operation over
+      // the whole frame stream — and could not be read by any compliant
+      // v2.3 parser that un-unsyncs at tag level.
+      //
+      // The correct behaviour: frame bodies are stored raw; the entire
+      // concatenated frame stream (headers + bodies) is unsynchronised
+      // once; the tag-level flag signals the reader to reverse it before
+      // parsing.
+      this.mp3tag.tags.v2.GEOB = [{
+        format: 'application/octet-stream',
+        filename: 'file.bin',
+        description: 'TEST',
+        object: [0xff, 0xfe, 0x01, 0x02, 0xff, 0x00, 0xff, 0xaa]
+      }]
+      this.mp3tag.save({
+        strict: true,
+        id3v2: { version: 3, unsynch: true, padding: 0 }
+      })
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+
+      const buf = new Uint8Array(this.mp3tag.buffer)
+      assert.strictEqual(buf[3], 3, 'major version')
+      assert.strictEqual(buf[5] & 0x80, 0x80, 'tag-level unsync flag set')
+
+      // The decisive on-disk assertion. A compliant v2.3 writer stores
+      // the frame BODY raw (not per-frame unsynched), so the GEOB frame
+      // size field in the header must equal the raw body size (49 bytes
+      // for this fixture). The buggy writer stored an already-unsynched
+      // body and declared its unsynched size (51 bytes: two 0x00 stuff
+      // bytes inserted after 0xFF in the object). We find GEOB in the
+      // tag-level un-unsynched stream and inspect its declared size.
+      const size = ((buf[6] & 0x7f) << 21) | ((buf[7] & 0x7f) << 14) |
+                   ((buf[8] & 0x7f) << 7) | (buf[9] & 0x7f)
+      const frameArea = Array.from(buf.slice(10, 10 + size))
+      const synched = []
+      for (let i = 0; i < frameArea.length; i++) {
+        synched.push(frameArea[i])
+        if (frameArea[i] === 0xff && frameArea[i + 1] === 0x00) i++
+      }
+      const geobAt = synched.findIndex((_, i) =>
+        synched[i] === 0x47 && synched[i + 1] === 0x45 &&
+        synched[i + 2] === 0x4f && synched[i + 3] === 0x42)
+      assert.ok(geobAt >= 0, 'GEOB header found in un-unsynched stream')
+      const declaredSize = (synched[geobAt + 4] << 24) |
+                           (synched[geobAt + 5] << 16) |
+                           (synched[geobAt + 6] << 8) |
+                            synched[geobAt + 7]
+      const rawBodySize =
+        1 + // encoding byte
+        ('application/octet-stream\0'.length) +
+        ('file.bin\0'.length) +
+        ('TEST\0'.length) +
+        8 // object
+      assert.strictEqual(declaredSize, rawBodySize,
+        'GEOB size field must equal raw body length (§3.3), not unsynched length')
+
+      // And the full round-trip still works.
+      this.mp3tag.read()
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+      assert.deepStrictEqual(this.mp3tag.tags.v2.GEOB, [{
+        format: 'application/octet-stream',
+        filename: 'file.bin',
+        description: 'TEST',
+        object: [0xff, 0xfe, 0x01, 0x02, 0xff, 0x00, 0xff, 0xaa]
+      }])
+    })
+
+    it('Honors the per-frame unsynchronisation flag in ID3v2.4 (§4.1.2)', function () {
+      // Companion to the v2.3 tag-level fix. The same decodeFrame branch
+      // that ignored tag-level un-unsync for v2.3 also ignored the v2.4
+      // per-frame unsync flag, because `version === 4` on an array is
+      // always false. After the refactor in this commit, decodeFrame's
+      // unsync path is driven solely by `frame.flags.unsynchronisation`
+      // for v2.4 — this test guards that path.
+      //
+      // We write a v2.4 tag with unsync enabled, then clear the tag-level
+      // unsync bit in the resulting buffer to simulate a standards-
+      // compliant writer. The reader must still decode the per-frame flag
+      // and un-unsynchronise the data.
+      const object = [0xff, 0xfe, 0x01, 0x02, 0xff, 0x00, 0xff, 0xaa]
+      this.mp3tag.tags.v2.GEOB = [{
+        format: 'application/octet-stream',
+        filename: 'file.bin',
+        description: 'TEST',
+        object
+      }]
+      this.mp3tag.save({
+        strict: true,
+        id3v2: { version: 4, unsynch: true, padding: 0 }
+      })
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+
+      // Clear the tag-level unsync flag (bit 7 of byte 5 in ID3 header)
+      // so the reader MUST consult the per-frame flag to decode correctly.
+      const buf = new Uint8Array(this.mp3tag.buffer)
+      assert.strictEqual(buf[5] & 0x80, 0x80, 'tag-level unsync bit set by writer')
+      buf[5] &= 0x7f
+
+      const mp3 = new MP3Tag(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength))
+      mp3.read({ id3v1: false })
+      if (mp3.error !== '') throw new Error(mp3.error)
+
+      assert.strictEqual(mp3.tags.v2Details.version[0], 4)
+      assert.deepStrictEqual(mp3.tags.v2.GEOB, [{
+        format: 'application/octet-stream',
+        filename: 'file.bin',
+        description: 'TEST',
+        object
+      }])
+    })
+
     it('Write data (unsynched)', function () {
       const geob = {
         format: 'application/octet-stream',


### PR DESCRIPTION
## Summary

ID3v2.2 §6.1 and ID3v2.3 §5 define unsynchronisation as a **tag-level** operation: when the flag is set, the entire concatenated frame stream is unsynchronised once and the reader reverses it before parsing. Frame sizes declared in headers refer to raw (pre-unsync) lengths.

The previous implementation unsynchronised each v2.3 frame body individually AND set the tag-level flag. Internally consistent (self-roundtrippable), but:
- Frame size fields declared unsynched lengths
- Frame headers were never unsynchronised despite sitting in a stream the tag-level flag claimed was unsynched
- Any compliant v2.3 reader that un-unsyncs at tag level would see misaligned frames and corrupt data

## Changes

- `encode()`: for v2.3/v2.2, write frame bodies raw and apply `unsynch()` once to the concatenated frame stream before setting the tag-level flag. v2.4 keeps per-frame unsync.
- `decode()`: when reading v2.3/v2.2 with tag-level flag set, un-unsynchronise the whole post-header region before frame parsing; track the post-synch length separately from the declared size.
- `decodeFrame()`: drop the dead tag-level fallback; only the v2.4 per-frame flag governs per-frame un-unsync. This subsumes the one-line fix in PR #665 (`version === 4` → `version[0] === 4`).

## Relationship to #665

This PR's `decodeFrame` refactor **supersedes the one-line fix in #665**. The regression test from #665 (per-frame unsync with tag-level bit cleared, v2.4) has been mirrored into this PR's test file as a companion assertion, so that merging this PR first does not lose that coverage.

If both PRs are merged, #666 should go first; #665's one-line change then becomes a no-op and the PR can be closed.

## Backward compatibility note

Tags written by earlier mp3tag.js releases with the old per-frame-unsync-plus-tag-level-bit layout will NOT be correctly read by this version. That format was non-compliant and unreadable by every other v2.3 parser anyway; any tag that can be read by mutagen, TagLib, eyeD3, Kid3, or Picard will continue to work.

## Test plan

- [x] `npm test` — 80 passing (78 → 80: two new tests)
- [x] v2.3 test: on-disk GEOB size field equals the raw body length (49), not the unsynched length (51). Fails on old code, passes on new.
- [x] v2.4 test (mirrored from #665): per-frame unsync decodes correctly when tag-level bit is cleared
- [x] Pre-existing "Write data (unsynched)" roundtrip test still passes