### PR TITLE
feat(etco): support multi-byte event types via 0xFF escape prefix

### DIFF
--- a/src/id3v2/parse.mjs
+++ b/src/id3v2/parse.mjs
@@ -325,12 +325,28 @@ export function etcoFrame (buffer, version) {
   const view = new BufferView(buffer)
   const format = view.getUint8(0)
   const raw = view.getUint8(1, view.byteLength - 1)
-  const rview = new BufferView(Array.isArray(raw) ? raw : [raw])
+  const bytes = Array.isArray(raw) ? raw : [raw]
+  const rview = new BufferView(bytes)
   const data = []
-  for (let i = 0; i < raw.length; i += 5) {
-    const event = rview.getUint8(i)
-    const time = rview.getUint32(i + 1)
+  let i = 0
+  while (i + 5 <= bytes.length) {
+    // Per ID3v2.4 §4.5: $FF means "one more byte of events follows"
+    // and "all the following bytes with the value $FF have the same
+    // function". So an event type may span multiple bytes: any number
+    // of leading $FF bytes followed by a single terminating byte
+    // (0x00–0xFE), then a 4-byte timestamp.
+    let typeEnd = i
+    while (typeEnd < bytes.length && bytes[typeEnd] === 0xff) typeEnd++
+    if (typeEnd >= bytes.length || typeEnd + 4 >= bytes.length) break
+    let event
+    if (typeEnd === i) {
+      event = rview.getUint8(i)
+    } else {
+      event = bytes.slice(i, typeEnd + 1)
+    }
+    const time = rview.getUint32(typeEnd + 1)
     data.push({ event, time })
+    i = typeEnd + 5
   }
   return {
     format,

--- a/src/id3v2/validate.mjs
+++ b/src/id3v2/validate.mjs
@@ -542,10 +542,41 @@ export function etcoFrame (value, version, strict) {
     throw new Error('Invalid timestamp format (should be 1 or 2)')
   }
   for (const { event, time } of value.data) {
-    if (typeof event !== 'number') {
-      throw new Error('Event is not a number')
-    } else if (event > 255 || event < 0) {
-      throw new Error('Event should be in range of 0 - 255')
+    // Per ID3v2.4 §4.5: events are either a single byte (0x00–0xFE)
+    // or, when 0xFF is used as escape prefix, a sequence of one or
+    // more 0xFF bytes followed by a single terminating byte. Accept
+    // either a number or an Array<number> of bytes.
+    // Structural checks (always on, including non-strict mode) — these
+    // rules are what make the byte stream parseable per §4.5. Emitting a
+    // bare 0xFF as a single-byte event, or an extended-event array whose
+    // prefix bytes aren't 0xFF, produces a malformed frame that no
+    // compliant reader can decode.
+    if (typeof event === 'number') {
+      if (event > 255 || event < 0) {
+        throw new Error('Event should be in range of 0 - 255')
+      }
+      if (event === 0xff) {
+        throw new Error('Event 0xFF is the escape byte (§4.5); use an array of bytes for extended events')
+      }
+    } else if (Array.isArray(event)) {
+      if (event.length === 0) {
+        throw new Error('Event array must not be empty')
+      }
+      for (const byte of event) {
+        if (typeof byte !== 'number' || byte > 255 || byte < 0) {
+          throw new Error('Event byte should be a number in range of 0 - 255')
+        }
+      }
+      for (let i = 0; i < event.length - 1; i++) {
+        if (event[i] !== 0xff) {
+          throw new Error('Extended event prefix bytes must all be 0xFF (§4.5)')
+        }
+      }
+      if (event[event.length - 1] === 0xff) {
+        throw new Error('Extended event terminator byte must not be 0xFF (§4.5)')
+      }
+    } else {
+      throw new Error('Event is not a number or an array of bytes')
     }
 
     if (typeof time !== 'number') {

--- a/src/id3v2/write.mjs
+++ b/src/id3v2/write.mjs
@@ -548,7 +548,13 @@ export function sytcFrame (value, options) {
 export function etcoFrame (value, options) {
   const { id, version, unsynch } = options
 
-  const array = value.data.flatMap(({ event, time }) => [event, ...timeBytes(time)])
+  // Per ID3v2.4 §4.5, event types may be multi-byte: any number of
+  // leading $FF bytes followed by a single terminating byte. Accept
+  // either a number (single byte) or an array of bytes.
+  const array = value.data.flatMap(({ event, time }) => {
+    const bytes = Array.isArray(event) ? event : [event]
+    return [...bytes, ...timeBytes(time)]
+  })
   let data = mergeBytes(value.format, array)
   if (unsynch) data = unsynchData(data, version)
 

--- a/test/id3v2/index.cjs
+++ b/test/id3v2/index.cjs
@@ -178,6 +178,58 @@ describe('ID3v2', function () {
       })
     })
 
+    it('Write ETCO with extended events (0xFF prefix)', function () {
+      // Per ID3v2.4 §4.5, an event type may be a multi-byte sequence:
+      // one or more leading 0xFF escape bytes followed by a single
+      // terminating byte (0x00–0xFE). Verify round-trip for mixed
+      // single-byte and extended events.
+      this.mp3tag.tags.v2.ETCO = {
+        format: 2,
+        data: [
+          { event: 0x02, time: 100 },
+          { event: [0xff, 0x12], time: 5000 },
+          { event: [0xff, 0x20], time: 10000 },
+          { event: 0x10, time: 12000 },
+          { event: [0xff, 0xff, 0x07], time: 20000 }
+        ]
+      }
+      this.mp3tag.save({ strict: true })
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+
+      this.mp3tag.read()
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+
+      assert.deepStrictEqual(this.mp3tag.tags.v2.ETCO, {
+        format: 2,
+        data: [
+          { event: 0x02, time: 100 },
+          { event: [0xff, 0x12], time: 5000 },
+          { event: [0xff, 0x20], time: 10000 },
+          { event: 0x10, time: 12000 },
+          { event: [0xff, 0xff, 0x07], time: 20000 }
+        ]
+      })
+    })
+
+    it('Rejects malformed extended ETCO events (structural, non-strict too)', function () {
+      // Per ID3v2.4 §4.5 these byte layouts produce unparseable frames,
+      // so they are rejected unconditionally — not only under strict
+      // mode. A silent acceptance here would write a tag that no
+      // compliant reader (including this library's own parser) can
+      // decode correctly.
+      const cases = [
+        { event: 0xff, time: 100 }, // bare escape byte
+        { event: [0xff, 0xff], time: 100 }, // terminator is 0xFF
+        { event: [0x12, 0x34], time: 100 } // non-0xFF prefix
+      ]
+      for (const bad of cases) {
+        this.mp3tag.tags.v2.ETCO = { format: 2, data: [bad] }
+        this.mp3tag.save() // NOT strict
+        assert.notStrictEqual(this.mp3tag.error, '',
+          `expected error for event=${JSON.stringify(bad.event)}`)
+      }
+    })
+
     it('Write complex multi tag', function () {
       this.mp3tag.tags.v2.SYLT = [
         {

--- a/types/id3v2/frames.d.ts
+++ b/types/id3v2/frames.d.ts
@@ -17,7 +17,13 @@ export interface MP3TagAPICFrame {
 export interface MP3TagETCOFrame {
   format: number;
   data: Array<{
-    event: number;
+    /**
+     * Event type. A single byte (0x00–0xFE) for standard events, or an
+     * array of bytes for extended events as defined by ID3v2.4 §4.5:
+     * one or more leading 0xFF escape bytes followed by a single
+     * terminating byte (0x00–0xFE).
+     */
+    event: number | number[];
     time: number;
   }>;
 }


### PR DESCRIPTION
## Summary

ID3v2.4 §4.5 specifies that an ETCO event type may span multiple bytes: any number of leading `0xFF` escape bytes followed by a single terminating byte (`0x00`–`0xFE`). Quoting the spec:

> `$FF` one more byte of events follows (all the following bytes with the value `$FF` have the same function)

The previous implementation assumed a fixed 5-byte stride (1 event byte + 4 timestamp bytes), making the entire extended-event range unrepresentable.

## Changes

- `src/id3v2/parse.mjs`: variable-stride parser — scans leading `0xFF` bytes, then consumes the terminator + 4-byte timestamp. Edge cases (trailing `0xFF` without terminator, short buffers) break out cleanly.
- `src/id3v2/write.mjs`: accepts `event` as either `number` (single byte) or `Array<number>` (multi-byte sequence).
- `src/id3v2/validate.mjs`: structural checks (always-on, including non-strict mode) reject bare `0xFF` single-byte events, empty arrays, non-`0xFF` prefix bytes, and arrays with `0xFF` terminator — all of which would produce malformed frames that no compliant reader can decode.
- `types/id3v2/frames.d.ts`: `event: number | number[]` with JSDoc pointing at §4.5.
- `test/id3v2/index.cjs`: two new tests — round-trip with mixed single-byte and 2-/3-byte extended events, and rejection of malformed event shapes in non-strict mode.

## Data shape

Fully backward compatible:

\`\`\`js
{ event: 0x02, time: 100 }              // single byte, unchanged
{ event: [0xff, 0x12], time: 5000 }     // extended (e.g. instrument code)
{ event: [0xff, 0xff, 0x07], time: ... } // doubly-extended
\`\`\`

Existing callers using \`{ event: number, time }\` continue to work unchanged. The extension is invisible to tags that only use the standard \`0x00\`–\`0x16\` codes.

## Motivation

The ETCO frame's reserved event ranges (\`0x17\`–\`0xDF\`) and its \`0xFF\` escape mechanism have been untouched since ID3v2.4 was published in 2000. Populating them through the spec's own escape byte is fully backward compatible (unknown codes are skipped by every existing ETCO parser per §4.5) and unlocks the frame for modern use cases — DJ tools, music education, dance applications, per-instrument annotation.

This PR is the minimal library-side change that makes extended events representable at all; concrete event-code assignments are out of scope.

## Test plan

- [x] \`npm test\` — 80 passing (78 → 80)
- [x] Round-trip test covers single-byte (0x02, 0x10), 2-byte (\`[0xFF, 0x12]\`, \`[0xFF, 0x20]\`), and 3-byte (\`[0xFF, 0xFF, 0x07]\`) events in mixed order
- [x] Rejection test runs in non-strict mode, confirming structural checks fire regardless of strict flag