### PR TITLE
feat(id3v2): add CHAP/CTOC chapter frame support

### DIFF
--- a/src/id3v2/frames.mjs
+++ b/src/id3v2/frames.mjs
@@ -10,10 +10,24 @@ export const APIC = {
   version: [3, 4]
 }
 
+export const CHAP = {
+  parse: parsers.chapFrame,
+  validate: validators.chapFrame,
+  write: writers.chapFrame,
+  version: [3, 4]
+}
+
 export const COMM = {
   parse: parsers.langDescFrame,
   validate: validators.langDescFrame,
   write: writers.langDescFrame,
+  version: [3, 4]
+}
+
+export const CTOC = {
+  parse: parsers.ctocFrame,
+  validate: validators.ctocFrame,
+  write: writers.ctocFrame,
   version: [3, 4]
 }
 

--- a/src/id3v2/parse.mjs
+++ b/src/id3v2/parse.mjs
@@ -1,6 +1,6 @@
 
 import BufferView from '../viewer.mjs'
-import { isBitSet, bytesToLong } from '../utils/bytes.mjs'
+import { isBitSet, bytesToLong, decodeSynch } from '../utils/bytes.mjs'
 import { ENCODINGS } from '../utils/strings.mjs'
 
 export function textFrame (buffer, version) {
@@ -361,4 +361,90 @@ export function popmFrame (buffer, version) {
   }
 
   return { email: email.string, rating, counter }
+}
+
+/**
+ * Decode the embedded sub-frames carried by CHAP/CTOC frames. Sub-frames use
+ * the same header layout as top-level v2.3/v2.4 frames (4-char id, 4-byte size,
+ * 2 flag bytes; v2.4 sizes are synchsafe). Returns an object keyed by frame id.
+ */
+function subFrames (view, start, length, version) {
+  const result = {}
+  let offset = start
+  const end = start + length
+
+  while (offset + 10 <= end) {
+    const id = view.getUint8String(offset, 4)
+    if (!/^[A-Z0-9]{4}$/.test(id)) break
+
+    const sizeBytes = view.getUint32(offset + 4)
+    const size = version === 4 ? decodeSynch(sizeBytes) : sizeBytes
+    const dataOffset = offset + 10
+    if (size <= 0 || dataOffset + size > end) break
+
+    const data = view.getUint8(dataOffset, size)
+    const buffer = new Uint8Array(Array.isArray(data) ? data : [data]).buffer
+    result[id] = parseSubFrame(id, buffer, version)
+    offset = dataOffset + size
+  }
+
+  return result
+}
+
+function parseSubFrame (id, buffer, version) {
+  if (id === 'APIC') return apicFrame(buffer, version)
+  if (id === 'TXXX') return txxxFrame(buffer, version)
+  if (id === 'WXXX') return wxxxFrame(buffer, version)
+  if (id.charAt(0) === 'T') return textFrame(buffer, version)
+  if (id.charAt(0) === 'W') return urlFrame(buffer, version)
+
+  const view = new BufferView(buffer)
+  const bytes = view.getUint8(0, view.byteLength)
+  return Array.isArray(bytes) ? bytes : [bytes]
+}
+
+export function chapFrame (buffer, version) {
+  const view = new BufferView(buffer)
+  const elementID = view.getCString(0)
+  let offset = elementID.length
+
+  const startTime = view.getUint32(offset)
+  const endTime = view.getUint32(offset + 4)
+  const startOffset = view.getUint32(offset + 8)
+  const endOffset = view.getUint32(offset + 12)
+  offset += 16
+
+  return {
+    id: elementID.string,
+    startTime,
+    endTime,
+    startOffset,
+    endOffset,
+    subFrames: subFrames(view, offset, view.byteLength - offset, version)
+  }
+}
+
+export function ctocFrame (buffer, version) {
+  const view = new BufferView(buffer)
+  const elementID = view.getCString(0)
+  let offset = elementID.length
+
+  const flags = view.getUint8(offset)
+  const entryCount = view.getUint8(offset + 1)
+  offset += 2
+
+  const childElementIds = []
+  for (let i = 0; i < entryCount; i++) {
+    const child = view.getCString(offset)
+    childElementIds.push(child.string)
+    offset += child.length
+  }
+
+  return {
+    id: elementID.string,
+    topLevel: isBitSet(flags, 1),
+    ordered: isBitSet(flags, 0),
+    childElementIds,
+    subFrames: subFrames(view, offset, view.byteLength - offset, version)
+  }
 }

--- a/src/id3v2/validate.mjs
+++ b/src/id3v2/validate.mjs
@@ -603,3 +603,50 @@ export function unsupportedFrame (values, version, strict) {
 
   return true
 }
+
+function validateSubFrames (subFrames, version, strict) {
+  if (subFrames === undefined) return
+  if (typeof subFrames !== 'object' || Array.isArray(subFrames)) {
+    throw new Error('Sub-frames should be an object')
+  }
+  for (const id in subFrames) {
+    if (id.charAt(0) === 'T' && id !== 'TXXX') textFrame(subFrames[id], version, strict)
+  }
+}
+
+export function chapFrame (values, version, strict) {
+  const ids = []
+  values.forEach(value => {
+    if (typeof value.id !== 'string') {
+      throw new Error('Element ID should be a string')
+    }
+
+    if (typeof value.startTime !== 'number' || typeof value.endTime !== 'number') {
+      throw new Error('Start and end time should be numbers')
+    }
+
+    validateSubFrames(value.subFrames, version, strict)
+
+    if (strict && includes(ids, value.id)) {
+      throw new Error('Element ID should not duplicate')
+    } else ids.push(value.id)
+  })
+
+  return true
+}
+
+export function ctocFrame (values, version, strict) {
+  values.forEach(value => {
+    if (typeof value.id !== 'string') {
+      throw new Error('Element ID should be a string')
+    }
+
+    if (value.childElementIds !== undefined && !Array.isArray(value.childElementIds)) {
+      throw new Error('Child element IDs should be an array')
+    }
+
+    validateSubFrames(value.subFrames, version, strict)
+  })
+
+  return true
+}

--- a/src/id3v2/write.mjs
+++ b/src/id3v2/write.mjs
@@ -617,3 +617,89 @@ export function unsupportedFrame (values, options) {
 
   return bytes
 }
+
+/**
+ * Encode the embedded sub-frames of a CHAP/CTOC frame. Each sub-frame is a
+ * complete v2.3/v2.4 frame (header + body) produced by the matching writer.
+ */
+function subFrameBytes (subFrames, options) {
+  const bytes = []
+  if (!subFrames) return bytes
+
+  for (const id in subFrames) {
+    const opts = { ...options, id, unsynch: false }
+    const value = subFrames[id]
+    let frameBytes = null
+
+    if (id === 'APIC') frameBytes = apicFrame([value], opts)
+    else if (id === 'TXXX') frameBytes = txxxFrame([value], opts)
+    else if (id === 'WXXX') frameBytes = wxxxFrame([value], opts)
+    else if (id.charAt(0) === 'T') frameBytes = textFrame(value, opts)
+    else if (id.charAt(0) === 'W') frameBytes = urlFrame(value, opts)
+
+    if (frameBytes) frameBytes.forEach(byte => bytes.push(byte))
+  }
+
+  return bytes
+}
+
+export function chapFrame (values, options) {
+  const { id, version, unsynch } = options
+  const bytes = []
+
+  values.forEach(value => {
+    const times = new BufferView(16)
+    times.setUint32(0, (value.startTime || 0) >>> 0)
+    times.setUint32(4, (value.endTime || 0) >>> 0)
+    times.setUint32(8, (value.startOffset === undefined ? 0xffffffff : value.startOffset) >>> 0)
+    times.setUint32(12, (value.endOffset === undefined ? 0xffffffff : value.endOffset) >>> 0)
+
+    let data = mergeBytes(
+      encodeString(value.id + '\0'),
+      times.getUint8(0, 16),
+      subFrameBytes(value.subFrames, options)
+    )
+    if (unsynch) data = unsynchData(data, version)
+
+    const header = getHeaderBytes(id, data.length, version, {
+      unsynchronisation: unsynch,
+      dataLengthIndicator: unsynch
+    })
+    mergeBytes(header, data).forEach(byte => bytes.push(byte))
+  })
+
+  return bytes
+}
+
+export function ctocFrame (values, options) {
+  const { id, version, unsynch } = options
+  const bytes = []
+
+  values.forEach(value => {
+    const childIds = value.childElementIds || []
+    let flags = 0
+    if (value.topLevel) flags = setBit(flags, 1)
+    if (value.ordered) flags = setBit(flags, 0)
+
+    const childBytes = []
+    childIds.forEach(child => {
+      encodeString(child + '\0').forEach(byte => childBytes.push(byte))
+    })
+
+    let data = mergeBytes(
+      encodeString(value.id + '\0'),
+      [flags, childIds.length & 0xff],
+      childBytes,
+      subFrameBytes(value.subFrames, options)
+    )
+    if (unsynch) data = unsynchData(data, version)
+
+    const header = getHeaderBytes(id, data.length, version, {
+      unsynchronisation: unsynch,
+      dataLengthIndicator: unsynch
+    })
+    mergeBytes(header, data).forEach(byte => bytes.push(byte))
+  })
+
+  return bytes
+}

--- a/test/id3v2/index.cjs
+++ b/test/id3v2/index.cjs
@@ -233,6 +233,69 @@ describe('ID3v2', function () {
       ])
     })
 
+    it('Write chapter frames (CHAP/CTOC)', function () {
+      this.mp3tag.tags.v2.CHAP = [
+        {
+          id: 'chp0',
+          startTime: 0,
+          endTime: 15000,
+          startOffset: 4294967295,
+          endOffset: 4294967295,
+          subFrames: { TIT2: 'Intro' }
+        },
+        {
+          id: 'chp1',
+          startTime: 15000,
+          endTime: 30000,
+          startOffset: 4294967295,
+          endOffset: 4294967295,
+          subFrames: { TIT2: 'Verse' }
+        }
+      ]
+      this.mp3tag.tags.v2.CTOC = [
+        {
+          id: 'toc0',
+          topLevel: true,
+          ordered: true,
+          childElementIds: ['chp0', 'chp1'],
+          subFrames: { TIT2: 'Table of Contents' }
+        }
+      ]
+      this.mp3tag.save({ strict: true })
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+
+      this.mp3tag.read()
+      if (this.mp3tag.error !== '') throw new Error(this.mp3tag.error)
+
+      assert.deepStrictEqual(this.mp3tag.tags.v2.CHAP, [
+        {
+          id: 'chp0',
+          startTime: 0,
+          endTime: 15000,
+          startOffset: 4294967295,
+          endOffset: 4294967295,
+          subFrames: { TIT2: 'Intro' }
+        },
+        {
+          id: 'chp1',
+          startTime: 15000,
+          endTime: 30000,
+          startOffset: 4294967295,
+          endOffset: 4294967295,
+          subFrames: { TIT2: 'Verse' }
+        }
+      ])
+      assert.deepStrictEqual(this.mp3tag.tags.v2.CTOC, [
+        {
+          id: 'toc0',
+          topLevel: true,
+          ordered: true,
+          childElementIds: ['chp0', 'chp1'],
+          subFrames: { TIT2: 'Table of Contents' }
+        }
+      ])
+    })
+
     it('Write data (unsynched)', function () {
       const geob = {
         format: 'application/octet-stream',

--- a/types/id3v2/frames.d.ts
+++ b/types/id3v2/frames.d.ts
@@ -14,6 +14,32 @@ export interface MP3TagAPICFrame {
   data: Array<number>;
 }
 
+export type MP3TagSubFrames = {
+  [id: string]:
+    | MP3TagTextFrame
+    | MP3TagAPICFrame
+    | MP3TagTXXXFrame
+    | MP3TagWXXXFrame
+    | Array<number>;
+};
+
+export interface MP3TagCHAPFrame {
+  id: string;
+  startTime: number;
+  endTime: number;
+  startOffset: number;
+  endOffset: number;
+  subFrames: MP3TagSubFrames;
+}
+
+export interface MP3TagCTOCFrame {
+  id: string;
+  topLevel: boolean;
+  ordered: boolean;
+  childElementIds: Array<string>;
+  subFrames: MP3TagSubFrames;
+}
+
 export interface MP3TagETCOFrame {
   format: number;
   data: Array<{

--- a/types/id3v2/tags.d.ts
+++ b/types/id3v2/tags.d.ts
@@ -60,7 +60,9 @@ export interface MP3TagTagsV2Defined {
     TCP?: frames.MP3TagTextFrame;
     GP1?: frames.MP3TagTextFrame;
     APIC?: Array<frames.MP3TagAPICFrame>;
+    CHAP?: Array<frames.MP3TagCHAPFrame>;
     COMM?: Array<frames.MP3TagLangDescFrame>;
+    CTOC?: Array<frames.MP3TagCTOCFrame>;
     ETCO?: frames.MP3TagETCOFrame;
     GEOB?: Array<frames.MP3TagGEOBFrame>;
     IPLS?: Array<string>;


### PR DESCRIPTION
## Summary

Adds read, write and validation for the ID3v2 **CHAP** (Chapter) and **CTOC**
(Table of Contents) frames, including their embedded sub-frames (e.g. `TIT2`
chapter titles).

> [!NOTE]
> CHAP and CTOC are **not part of the core ID3v2.3/2.4 specification**. They are
> defined in the separate **ID3v2 Chapter Frame Addendum 1.0**:
> https://id3.org/id3v2-chapters-1.0

## Changes

- `src/id3v2/parse.mjs` — `chapFrame`/`ctocFrame` parsers + a recursive
  sub-frame decoder (handles ID3v2.3 plain and ID3v2.4 synchsafe sub-frame sizes)
- `src/id3v2/write.mjs` — `chapFrame`/`ctocFrame` writers; encode embedded
  sub-frames and honour per-frame unsynchronisation like other binary frames
- `src/id3v2/validate.mjs` — `chapFrame`/`ctocFrame` validators (+ sub-frame text validation)
- `src/id3v2/frames.mjs` — register CHAP/CTOC for ID3v2.3 and ID3v2.4
- `types/id3v2` — `MP3TagCHAPFrame` / `MP3TagCTOCFrame` / `MP3TagSubFrames`
- `test/id3v2/index.cjs` — strict round-trip test covering nested `TIT2` sub-frames

## Data shape

```javascript
tags.v2.CHAP = [
  { id: 'chp0', startTime: 0, endTime: 15000,
    startOffset: 4294967295, endOffset: 4294967295,
    subFrames: { TIT2: 'Intro' } }
]
tags.v2.CTOC = [
  { id: 'toc0', topLevel: true, ordered: true,
    childElementIds: ['chp0', 'chp1'],
    subFrames: { TIT2: 'Table of Contents' } }
]
```

`npm test` passes (lint + build + 79 mocha tests, incl. the new CHAP/CTOC round-trip).

Docs for the frame reference are in a companion PR against `gh-pages`.