### PR TITLE
Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,20 @@
     "Kolja Koischwitz"
   ],
   "main": "dist/mp3tag.js",
-  "types": "types/index.d.ts",
+  "module": "dist/mp3tag.mjs",
+  "types": "types/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.mts",
+        "default": "./dist/mp3tag.mjs"
+      },
+      "require": {
+        "types": "./types/index.d.cts",
+        "default": "./dist/mp3tag.js"
+      }
+    }
+  },
   "directories": {
     "example": "examples",
     "test": "test"

--- a/types/index.d.cts
+++ b/types/index.d.cts
@@ -1,0 +1,76 @@
+import type { MP3TagTags } from './tags';
+
+type RecursivePartial<T> = {
+  [P in keyof T]?:
+  T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+  T[P] extends object | undefined ? RecursivePartial<T[P]> :
+  T[P];
+};
+
+export type MP3Buffer = Buffer | ArrayBuffer;
+
+export type MP3TagV2Versions = 2 | 3 | 4;
+
+export type MP3TagEncodings =
+  | 'utf8' | 'utf-8'
+  | 'utf16' | 'utf16be'
+  | 'utf-16' | 'utf-16be'
+  | 'windows1251' | 'windows-1251' | 'windows1252' | 'windows-1252'
+  | 'latin1' | 'iso-8859-1' | 'iso88591';
+
+export interface MP3TagDefaultReadOptions {
+  id3v1: boolean;
+  id3v2: boolean;
+  mp4: boolean;
+  aiff: boolean;
+  aac: boolean;
+  unsupported: boolean;
+  encoding: MP3TagEncodings;
+}
+
+export interface MP3TagDefaultWriteOptions {
+  strict: boolean;
+  encoding: MP3TagEncodings;
+  emptyAudioNone: boolean;
+  id3v1: {
+    include: boolean;
+    encoding: MP3TagEncodings;
+  };
+  id3v2: {
+    include: boolean;
+    unsynch: boolean;
+    version: MP3TagV2Versions;
+    padding: number;
+    unsupported: boolean;
+    encoding: MP3TagEncodings;
+  };
+  mp4: {
+    language: 'und'
+  };
+}
+
+export type MP3TagReadOptions = RecursivePartial<MP3TagDefaultReadOptions>;
+export type MP3TagWriteOptions = RecursivePartial<MP3TagDefaultWriteOptions>;
+
+export class MP3Tag {
+  readonly name = 'MP3Tag';
+  readonly version = '3.16.0';
+
+  verbose: boolean;
+  buffer: MP3Buffer;
+  tags: MP3TagTags;
+  error: string;
+
+  static  readBuffer(buffer: MP3Buffer, options?: MP3TagReadOptions, verbose?: boolean): MP3TagTags;
+  static  readBlob(blob: Blob, options?: MP3TagReadOptions): Promise<MP3TagTags>;
+  static  writeBuffer(buffer: MP3Buffer, tags: MP3TagTags, options?: MP3TagWriteOptions, verbose?: boolean): MP3Buffer;
+  static  getAudioBuffer(buffer: MP3Buffer, emptyNone?: boolean): MP3Buffer;
+  
+  constructor (buffer: MP3Buffer, verbose?: boolean);
+  read (options?: MP3TagReadOptions): MP3TagTags;
+  save (options?: MP3TagWriteOptions): MP3Buffer;
+  remove (): boolean;
+  getAudio (emptyNone?: boolean): MP3Buffer;
+}
+
+export = MP3Tag;

--- a/types/index.d.mts
+++ b/types/index.d.mts
@@ -1,10 +1,10 @@
-import type { MP3TagTags } from './tags';
+import type { MP3TagTags } from './tags.d.ts';
 
 type RecursivePartial<T> = {
   [P in keyof T]?:
-    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
-    T[P] extends object | undefined ? RecursivePartial<T[P]> :
-    T[P];
+  T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+  T[P] extends object | undefined ? RecursivePartial<T[P]> :
+  T[P];
 };
 
 export type MP3Buffer = Buffer | ArrayBuffer;


### PR DESCRIPTION
Currently the type exports are wrong and i results in an erroneous .default type dangling off the MP3Tag default export. 

Modify config and declarations to pass https://arethetypeswrong.github.io/?p=mp3tag.js%403.16.0
