### PR TITLE
refactor(id3v2): dedupe multi-format support, remove dead code

### DIFF
--- a/src/aac/index.mjs
+++ b/src/aac/index.mjs
@@ -2,7 +2,7 @@
 import BufferView from '../viewer.mjs'
 import * as ID3v2 from '../id3v2/index.mjs'
 import { mergeBytes } from '../utils/bytes.mjs'
-import { encoding2Index } from '../utils/strings.mjs'
+import { encodeID3v2 } from '../utils/container.mjs'
 
 /**
  * AAC/ADTS File Structure:
@@ -76,17 +76,6 @@ export function decode (buffer, options = {}) {
 }
 
 /**
- * Validate tags for writing to AAC
- * @param {object} tags
- * @param {boolean} strict
- * @param {object} options
- * @returns {boolean}
- */
-export function validate (tags, strict, options) {
-  return ID3v2.validate(tags, strict, options)
-}
-
-/**
  * Encode ID3v2 tags into AAC buffer
  * @param {ArrayBuffer|Buffer} buffer
  * @param {object} tags
@@ -94,29 +83,11 @@ export function validate (tags, strict, options) {
  * @returns {ArrayBuffer}
  */
 export function encode (buffer, tags, options = {}) {
-  const defaultVersion = tags.v2Details ? tags.v2Details.version[0] : 3
-  const defaultEncoding = 'utf-8'
-
-  const id3v2Options = {
-    version: defaultVersion,
-    padding: options.id3v2?.padding ?? 1024,
-    unsynch: true, // Unsynchronisation recommended for AAC
-    unsupported: false,
-    encoding: defaultEncoding,
-    ...options.id3v2
-  }
-
-  id3v2Options.encodingIndex = encoding2Index(id3v2Options.encoding)
-
-  if (options.strict !== false) {
-    ID3v2.validate(tags.v2, options.strict, id3v2Options)
-  }
+  // Unsynchronisation is recommended for AAC; default to 1024 bytes of padding
+  const id3Data = encodeID3v2(tags, options, { padding: 1024, unsynch: true })
 
   // Get audio data without existing ID3 tags
   const audioData = new Uint8Array(getAudioBuffer(buffer))
-
-  // Encode new ID3v2 tag
-  const id3Data = new Uint8Array(ID3v2.encode(tags.v2, id3v2Options))
 
   // Prepend ID3v2 tag to audio
   const result = mergeBytes(id3Data, audioData)

--- a/src/aiff/index.mjs
+++ b/src/aiff/index.mjs
@@ -2,7 +2,7 @@
 import BufferView from '../viewer.mjs'
 import * as ID3v2 from '../id3v2/index.mjs'
 import { mergeBytes } from '../utils/bytes.mjs'
-import { encoding2Index } from '../utils/strings.mjs'
+import { encodeID3v2 } from '../utils/container.mjs'
 
 /**
  * AIFF File Structure:
@@ -110,17 +110,6 @@ export function decode (buffer, options = {}) {
 }
 
 /**
- * Validate tags for writing to AIFF
- * @param {object} tags
- * @param {boolean} strict
- * @param {object} options
- * @returns {boolean}
- */
-export function validate (tags, strict, options) {
-  return ID3v2.validate(tags, strict, options)
-}
-
-/**
  * Encode ID3v2 tags into AIFF buffer
  * @param {ArrayBuffer|Buffer} buffer
  * @param {object} tags
@@ -128,25 +117,7 @@ export function validate (tags, strict, options) {
  * @returns {ArrayBuffer}
  */
 export function encode (buffer, tags, options = {}) {
-  const defaultVersion = tags.v2Details ? tags.v2Details.version[0] : 3
-  const defaultEncoding = 'utf-8'
-
-  const id3v2Options = {
-    version: defaultVersion,
-    padding: 0,
-    unsynch: false,
-    unsupported: false,
-    encoding: defaultEncoding,
-    ...options.id3v2
-  }
-
-  id3v2Options.encodingIndex = encoding2Index(id3v2Options.encoding)
-
-  if (options.strict !== false) {
-    ID3v2.validate(tags.v2, options.strict, id3v2Options)
-  }
-
-  const id3Data = new Uint8Array(ID3v2.encode(tags.v2, id3v2Options))
+  const id3Data = encodeID3v2(tags, options)
   const id3Chunk = buildID3Chunk(id3Data)
 
   return rebuildAIFFWithID3(buffer, id3Chunk)

--- a/src/mp3tag.mjs
+++ b/src/mp3tag.mjs
@@ -12,6 +12,16 @@ import { overwriteDefault } from './utils/objects.mjs'
 import { isBuffer } from './utils/types.mjs'
 import { encoding2Index } from './utils/strings.mjs'
 
+// Container/stream formats that embed an ID3v2 tag. Checked before the raw
+// MP3 ID3v1/ID3v2 path. AIFF is listed before MP4 because its `FORM` signature
+// is more specific. Each entry exposes a uniform interface over its module so
+// read/write/getAudio can share a single loop instead of one branch per format.
+const CONTAINERS = [
+  { name: 'aiff', label: 'AIFF', module: AIFF, detect: AIFF.hasAIFF, hasID3: AIFF.hasID3 },
+  { name: 'mp4', label: 'MP4', module: MP4, detect: MP4.hasMP4, hasID3: MP4.hasID32 },
+  { name: 'aac', label: 'AAC/ADTS', module: AAC, detect: AAC.hasAAC, hasID3: AAC.hasID3 }
+]
+
 export default class MP3Tag {
   get name () { return 'MP3Tag' }
   set name (value) { throw new Error('Unable to set this property') }
@@ -46,354 +56,46 @@ export default class MP3Tag {
       encoding: 'utf-8'
     })
 
-    // Check for AIFF container first (before MP4 since it's more specific)
-    if (options.aiff && AIFF.hasAIFF(buffer)) {
-      if (verbose) console.log('AIFF container detected')
-      if (AIFF.hasID3(buffer)) {
-        if (verbose) console.log('ID3 chunk found, reading...')
-        const { unsupported } = options
-        const result = AIFF.decode(buffer, { unsupported })
-        if (result) {
-          if (verbose) console.log('ID3 chunk reading finished')
-          tags.v2 = { ...result.tags }
-          tags.v2Details = result.details
-        }
+    // Container/stream formats embed their ID3v2 tag in a format-specific
+    // location. When one matches we read its ID3v2 data and skip the raw
+    // ID3v1/ID3v2 path below.
+    let container = null
+    for (const fmt of CONTAINERS) {
+      if (options[fmt.name] && fmt.detect(buffer)) {
+        container = fmt
+        break
       }
-
-      Object.defineProperties(tags, {
-        title: {
-          get: function () {
-            return (this.v2 && (this.v2.TIT2 || this.v2.TT2)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TT2' : 'TIT2'] = value
-            }
-          }
-        },
-        artist: {
-          get: function () {
-            return (this.v2 && (this.v2.TPE1 || this.v2.TP1)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TP1' : 'TPE1'] = value
-            }
-          }
-        },
-        album: {
-          get: function () {
-            return (this.v2 && (this.v2.TALB || this.v2.TAL)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TAL' : 'TALB'] = value
-            }
-          }
-        },
-        year: {
-          get: function () {
-            return (this.v2 && (this.v2.TYER || this.v2.TDRC || this.v2.TYE)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              if (version === 2) this.v2.TYE = value
-              else if (version === 3) this.v2.TYER = value
-              else if (version === 4) this.v2.TDRC = value
-            }
-          }
-        },
-        comment: {
-          get: function () {
-            let text = ''
-            if (this.v2 && (this.v2.COMM || this.v2.COM)) {
-              const comm = this.v2.COMM || this.v2.COM
-              if (Array.isArray(comm) && comm.length > 0) text = comm[0].text
-            }
-            return text
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'COM' : 'COMM'] = [{
-                language: 'eng',
-                descriptor: '',
-                text: value
-              }]
-            }
-          }
-        },
-        track: {
-          get: function () {
-            return (this.v2 && (
-              (this.v2.TRCK && this.v2.TRCK.split('/')[0]) ||
-              (this.v2.TRK && this.v2.TRK.split('/')[0])
-            )) || ''
-          },
-          set: function (value) {
-            if (this.v2 && value !== '') {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TRK' : 'TRCK'] = value
-            }
-          }
-        },
-        genre: {
-          get: function () {
-            return (this.v2 && (this.v2.TCON || this.v2.TCO)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TCO' : 'TCON'] = value
-            }
-          }
-        }
-      })
-
-      return tags
     }
 
-    // Check for MP4 container
-    if (options.mp4 && MP4.hasMP4(buffer)) {
-      if (verbose) console.log('MP4 container detected')
-      if (MP4.hasID32(buffer)) {
-        if (verbose) console.log('ID32 box found, reading...')
+    if (container) {
+      if (verbose) console.log(`${container.label} container detected`)
+      if (container.hasID3(buffer)) {
+        if (verbose) console.log('ID3v2 found, reading...')
         const { unsupported } = options
-        const result = MP4.decode(buffer, { unsupported })
-        if (result) {
-          if (verbose) console.log('ID32 reading finished')
-          tags.v2 = { ...result.tags }
-          tags.v2Details = result.details
-        }
-      }
-
-      Object.defineProperties(tags, {
-        title: {
-          get: function () {
-            return (this.v2 && (this.v2.TIT2 || this.v2.TT2)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TT2' : 'TIT2'] = value
-            }
-          }
-        },
-        artist: {
-          get: function () {
-            return (this.v2 && (this.v2.TPE1 || this.v2.TP1)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TP1' : 'TPE1'] = value
-            }
-          }
-        },
-        album: {
-          get: function () {
-            return (this.v2 && (this.v2.TALB || this.v2.TAL)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TAL' : 'TALB'] = value
-            }
-          }
-        },
-        year: {
-          get: function () {
-            return (this.v2 && (this.v2.TYER || this.v2.TDRC || this.v2.TYE)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              if (version === 2) this.v2.TYE = value
-              else if (version === 3) this.v2.TYER = value
-              else if (version === 4) this.v2.TDRC = value
-            }
-          }
-        },
-        comment: {
-          get: function () {
-            let text = ''
-            if (this.v2 && (this.v2.COMM || this.v2.COM)) {
-              const comm = this.v2.COMM || this.v2.COM
-              if (Array.isArray(comm) && comm.length > 0) text = comm[0].text
-            }
-            return text
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'COM' : 'COMM'] = [{
-                language: 'eng',
-                descriptor: '',
-                text: value
-              }]
-            }
-          }
-        },
-        track: {
-          get: function () {
-            return (this.v2 && (
-              (this.v2.TRCK && this.v2.TRCK.split('/')[0]) ||
-              (this.v2.TRK && this.v2.TRK.split('/')[0])
-            )) || ''
-          },
-          set: function (value) {
-            if (this.v2 && value !== '') {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TRK' : 'TRCK'] = value
-            }
-          }
-        },
-        genre: {
-          get: function () {
-            return (this.v2 && (this.v2.TCON || this.v2.TCO)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TCO' : 'TCON'] = value
-            }
-          }
-        }
-      })
-
-      return tags
-    }
-
-    // Check for AAC/ADTS (has ID3v2 prepended like MP3, but audio uses 0xFFF sync)
-    if (options.aac && AAC.hasAAC(buffer)) {
-      if (verbose) console.log('AAC/ADTS detected')
-      if (AAC.hasID3(buffer)) {
-        if (verbose) console.log('ID3v2 found in AAC, reading...')
-        const { unsupported } = options
-        const result = AAC.decode(buffer, { unsupported })
+        const result = container.module.decode(buffer, { unsupported })
         if (result) {
           if (verbose) console.log('ID3v2 reading finished')
           tags.v2 = { ...result.tags }
           tags.v2Details = result.details
         }
       }
+    } else {
+      if (options.id3v1 && ID3v1.hasID3v1(buffer)) {
+        if (verbose) console.log('ID3v1 found, reading...')
+        const { tags: v1Tags, details } = ID3v1.decode(buffer, options.encoding)
+        if (verbose) console.log('ID3v1 reading finished')
+        tags.v1 = { ...v1Tags }
+        tags.v1Details = details
+      }
 
-      Object.defineProperties(tags, {
-        title: {
-          get: function () {
-            return (this.v2 && (this.v2.TIT2 || this.v2.TT2)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TT2' : 'TIT2'] = value
-            }
-          }
-        },
-        artist: {
-          get: function () {
-            return (this.v2 && (this.v2.TPE1 || this.v2.TP1)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TP1' : 'TPE1'] = value
-            }
-          }
-        },
-        album: {
-          get: function () {
-            return (this.v2 && (this.v2.TALB || this.v2.TAL)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TAL' : 'TALB'] = value
-            }
-          }
-        },
-        year: {
-          get: function () {
-            return (this.v2 && (this.v2.TYER || this.v2.TDRC || this.v2.TYE)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              if (version === 2) this.v2.TYE = value
-              else if (version === 3) this.v2.TYER = value
-              else if (version === 4) this.v2.TDRC = value
-            }
-          }
-        },
-        comment: {
-          get: function () {
-            let text = ''
-            if (this.v2 && (this.v2.COMM || this.v2.COM)) {
-              const comm = this.v2.COMM || this.v2.COM
-              if (Array.isArray(comm) && comm.length > 0) text = comm[0].text
-            }
-            return text
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'COM' : 'COMM'] = [{
-                language: 'eng',
-                descriptor: '',
-                text: value
-              }]
-            }
-          }
-        },
-        track: {
-          get: function () {
-            return (this.v2 && (
-              (this.v2.TRCK && this.v2.TRCK.split('/')[0]) ||
-              (this.v2.TRK && this.v2.TRK.split('/')[0])
-            )) || ''
-          },
-          set: function (value) {
-            if (this.v2 && value !== '') {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TRK' : 'TRCK'] = value
-            }
-          }
-        },
-        genre: {
-          get: function () {
-            return (this.v2 && (this.v2.TCON || this.v2.TCO)) || ''
-          },
-          set: function (value) {
-            if (this.v2) {
-              const version = this.v2Details.version[0]
-              this.v2[version === 2 ? 'TCO' : 'TCON'] = value
-            }
-          }
-        }
-      })
-
-      return tags
-    }
-
-    if (options.id3v1 && ID3v1.hasID3v1(buffer)) {
-      if (verbose) console.log('ID3v1 found, reading...')
-      const { tags: v1Tags, details } = ID3v1.decode(buffer, options.encoding)
-      if (verbose) console.log('ID3v1 reading finished')
-      tags.v1 = { ...v1Tags }
-      tags.v1Details = details
-    }
-
-    if (options.id3v2 && ID3v2.hasID3v2(buffer)) {
-      if (verbose) console.log('ID3v2 found, reading...')
-      const { unsupported } = options
-      const { tags: v2Tags, details } = ID3v2.decode(buffer, 0, unsupported)
-      if (verbose) console.log('ID3v2 reading finished')
-      tags.v2 = { ...v2Tags }
-      tags.v2Details = details
+      if (options.id3v2 && ID3v2.hasID3v2(buffer)) {
+        if (verbose) console.log('ID3v2 found, reading...')
+        const { unsupported } = options
+        const { tags: v2Tags, details } = ID3v2.decode(buffer, 0, unsupported)
+        if (verbose) console.log('ID3v2 reading finished')
+        tags.v2 = { ...v2Tags }
+        tags.v2Details = details
+      }
     }
 
     Object.defineProperties(tags, {
@@ -543,50 +245,22 @@ export default class MP3Tag {
       }
     })
 
-    // Handle AIFF containers separately
-    if (AIFF.hasAIFF(buffer)) {
+    // Container/stream formats embed the ID3v2 tag in their own structure and
+    // are rewritten in place by the format module. The `mp4` option is ignored
+    // by encoders that don't use it.
+    for (const fmt of CONTAINERS) {
+      if (!fmt.detect(buffer)) continue
+
       if (typeof tags.v2 === 'undefined') {
-        throw new Error('No ID3v2 tags to write to AIFF')
+        throw new Error(`No ID3v2 tags to write to ${fmt.label}`)
       }
 
-      if (verbose) console.log('Writing ID3v2 to AIFF container...')
+      if (verbose) console.log(`Writing ID3v2 to ${fmt.label} container...`)
       options.id3v2.encoding = options.id3v2.encoding || options.encoding
-      const result = AIFF.encode(buffer, tags, {
-        strict: options.strict,
-        id3v2: options.id3v2
-      })
-
-      return typeof Buffer !== 'undefined' ? Buffer.from(result) : result
-    }
-
-    // Handle MP4 containers separately
-    if (MP4.hasMP4(buffer)) {
-      if (typeof tags.v2 === 'undefined') {
-        throw new Error('No ID3v2 tags to write to MP4')
-      }
-
-      if (verbose) console.log('Writing ID3v2 to MP4 container...')
-      options.id3v2.encoding = options.id3v2.encoding || options.encoding
-      const result = MP4.encode(buffer, tags, {
+      const result = fmt.module.encode(buffer, tags, {
         strict: options.strict,
         id3v2: options.id3v2,
         mp4: options.mp4
-      })
-
-      return typeof Buffer !== 'undefined' ? Buffer.from(result) : result
-    }
-
-    // Handle AAC/ADTS files separately
-    if (AAC.hasAAC(buffer)) {
-      if (typeof tags.v2 === 'undefined') {
-        throw new Error('No ID3v2 tags to write to AAC')
-      }
-
-      if (verbose) console.log('Writing ID3v2 to AAC/ADTS...')
-      options.id3v2.encoding = options.id3v2.encoding || options.encoding
-      const result = AAC.encode(buffer, tags, {
-        strict: options.strict,
-        id3v2: options.id3v2
       })
 
       return typeof Buffer !== 'undefined' ? Buffer.from(result) : result
@@ -646,19 +320,10 @@ export default class MP3Tag {
       throw new TypeError('buffer is not ArrayBuffer/Buffer')
     }
 
-    // Handle AIFF containers - return whole file (audio interleaved with metadata)
-    if (AIFF.hasAIFF(buffer)) {
-      return AIFF.getAudioBuffer(buffer)
-    }
-
-    // Handle MP4 containers - extract mdat contents
-    if (MP4.hasMP4(buffer)) {
-      return MP4.getAudioBuffer(buffer)
-    }
-
-    // Handle AAC/ADTS - strip ID3v2 and find ADTS sync
-    if (AAC.hasAAC(buffer)) {
-      return AAC.getAudioBuffer(buffer)
+    // Container/stream formats extract their audio data via the format module
+    // (e.g. AIFF returns the whole file, MP4 extracts mdat, AAC strips ID3v2).
+    for (const fmt of CONTAINERS) {
+      if (fmt.detect(buffer)) return fmt.module.getAudioBuffer(buffer)
     }
 
     if (ID3v1.hasID3v1(buffer)) {

--- a/src/mp4/boxes.mjs
+++ b/src/mp4/boxes.mjs
@@ -113,29 +113,6 @@ export function findID32Box (buffer) {
 }
 
 /**
- * Parse ID32 box and extract ID3v2 data
- * @param {BufferView} view
- * @param {number} offset - Start of ID32 box
- * @param {number} size - Size of ID32 box
- * @returns {{ language: string, id3Data: ArrayBuffer }}
- */
-export function parseID32Box (view, offset, size) {
-  // Skip header (8 bytes), version/flags (4 bytes)
-  const dataStart = offset + 8
-  const languageBytes = view.getUint8(dataStart + 4, 2)
-  const langValue = (languageBytes[0] << 8) | languageBytes[1]
-  const language = decodeLanguage(langValue)
-
-  const id3Offset = dataStart + 4 + 2
-  const id3Size = size - 8 - 4 - 2
-
-  const id3Bytes = view.getUint8(id3Offset, id3Size)
-  const id3Data = new Uint8Array(Array.isArray(id3Bytes) ? id3Bytes : [id3Bytes]).buffer
-
-  return { language, id3Data }
-}
-
-/**
  * Build an ID32 box from ID3v2 data
  * @param {ArrayBuffer|Uint8Array} id3Data - Raw ID3v2 bytes
  * @param {string} language - ISO-639-2/T language code (default: 'und')
@@ -204,48 +181,7 @@ export function decodeLanguage (packed) {
  * @returns {Uint8Array}
  */
 function buildMetaStructure (id32Box) {
-  // hdlr box for meta (required by spec)
-  const hdlrData = new BufferView(25)
-  hdlrData.setUint32(0, 33) // size
-  hdlrData.setUint8(4, 'h'.charCodeAt(0))
-  hdlrData.setUint8(5, 'd'.charCodeAt(0))
-  hdlrData.setUint8(6, 'l'.charCodeAt(0))
-  hdlrData.setUint8(7, 'r'.charCodeAt(0))
-  // version/flags: 0
-  // pre_defined: 0
-  hdlrData.setUint8(16, 'm'.charCodeAt(0))
-  hdlrData.setUint8(17, 'd'.charCodeAt(0))
-  hdlrData.setUint8(18, 'i'.charCodeAt(0))
-  hdlrData.setUint8(19, 'r'.charCodeAt(0))
-  // reserved: 0, 0, 0
-  // name: null-terminated empty string (implicit with remaining zeros)
-
-  const hdlrBox = new Uint8Array(33)
-  new DataView(hdlrBox.buffer).setUint32(0, 33)
-  hdlrBox[4] = 'h'.charCodeAt(0)
-  hdlrBox[5] = 'd'.charCodeAt(0)
-  hdlrBox[6] = 'l'.charCodeAt(0)
-  hdlrBox[7] = 'r'.charCodeAt(0)
-  // version/flags at 8-11: 0
-  // pre_defined at 12-15: 0
-  hdlrBox[16] = 'm'.charCodeAt(0)
-  hdlrBox[17] = 'd'.charCodeAt(0)
-  hdlrBox[18] = 'i'.charCodeAt(0)
-  hdlrBox[19] = 'r'.charCodeAt(0)
-  // reserved 20-31: 0
-  hdlrBox[32] = 0 // name: null terminator
-
-  // meta box: header (8) + version/flags (4) + hdlr + ID32
-  const metaSize = 8 + 4 + hdlrBox.length + id32Box.length
-  const metaHeader = new Uint8Array(12)
-  new DataView(metaHeader.buffer).setUint32(0, metaSize)
-  metaHeader[4] = 'm'.charCodeAt(0)
-  metaHeader[5] = 'e'.charCodeAt(0)
-  metaHeader[6] = 't'.charCodeAt(0)
-  metaHeader[7] = 'a'.charCodeAt(0)
-  // version/flags at 8-11: 0
-
-  const metaBox = mergeBytes(metaHeader, hdlrBox, id32Box)
+  const metaBox = buildMetaWithID32(id32Box)
 
   // udta box: header (8) + meta
   const udtaSize = 8 + metaBox.length

--- a/src/mp4/index.mjs
+++ b/src/mp4/index.mjs
@@ -7,8 +7,7 @@ import {
   findID32Box,
   buildID32Box,
   rebuildMP4WithID32,
-  findMdatBox,
-  findBox
+  findMdatBox
 } from './boxes.mjs'
 
 /**
@@ -143,47 +142,4 @@ export function getAudioBuffer (buffer) {
   const audioData = new Uint8Array(Array.isArray(audioBytes) ? audioBytes : [audioBytes])
 
   return typeof Buffer !== 'undefined' ? Buffer.from(audioData.buffer) : audioData.buffer
-}
-
-/**
- * Get the full MP4 buffer without ID32 tags (for rewriting)
- * This removes the ID32 box but keeps the rest of the MP4 structure intact
- * @param {ArrayBuffer|Buffer} buffer
- * @returns {ArrayBuffer}
- */
-export function getMP4WithoutID32 (buffer) {
-  const id32Info = findID32Box(buffer)
-  if (!id32Info) {
-    // No ID32 to remove
-    return buffer
-  }
-
-  const originalBytes = new Uint8Array(buffer)
-  const view = new BufferView(buffer)
-
-  // Find parent boxes to update their sizes
-  const moov = findBox(view, 0, view.byteLength, 'moov')
-  const udta = moov ? findBox(view, moov.dataStart, moov.end, 'udta') : null
-  const meta = udta ? findBox(view, udta.dataStart, udta.end, 'meta') : null
-
-  if (!moov || !udta || !meta) {
-    return buffer
-  }
-
-  const sizeDiff = -id32Info.size
-
-  // Remove ID32 box
-  const before = originalBytes.slice(0, id32Info.offset)
-  const after = originalBytes.slice(id32Info.end)
-  const merged = new Uint8Array(before.length + after.length)
-  merged.set(before, 0)
-  merged.set(after, before.length)
-
-  // Update parent box sizes
-  const resultView = new DataView(merged.buffer)
-  resultView.setUint32(meta.offset, meta.size + sizeDiff)
-  resultView.setUint32(udta.offset, udta.size + sizeDiff)
-  resultView.setUint32(moov.offset, moov.size + sizeDiff)
-
-  return typeof Buffer !== 'undefined' ? Buffer.from(merged.buffer) : merged.buffer
 }

--- a/src/mp4/index.mjs
+++ b/src/mp4/index.mjs
@@ -1,7 +1,7 @@
 
 import BufferView from '../viewer.mjs'
 import * as ID3v2 from '../id3v2/index.mjs'
-import { encoding2Index } from '../utils/strings.mjs'
+import { encodeID3v2 } from '../utils/container.mjs'
 
 import {
   findID32Box,
@@ -68,17 +68,6 @@ export function decode (buffer, options = {}) {
 }
 
 /**
- * Validate tags for writing to MP4
- * @param {object} tags - ID3v2 tags object
- * @param {boolean} strict - Strict validation mode
- * @param {object} options - Write options
- * @returns {boolean}
- */
-export function validate (tags, strict, options) {
-  return ID3v2.validate(tags, strict, options)
-}
-
-/**
  * Encode ID3v2 tags into MP4 buffer with ID32 box
  * @param {ArrayBuffer|Buffer} buffer - Original MP4 buffer
  * @param {object} tags - Tags object with v2 property
@@ -91,32 +80,13 @@ export function validate (tags, strict, options) {
  * @returns {ArrayBuffer}
  */
 export function encode (buffer, tags, options = {}) {
-  const defaultVersion = tags.v2Details ? tags.v2Details.version[0] : 3
-  const defaultEncoding = 'utf-8'
-
-  const id3v2Options = {
-    version: defaultVersion,
-    padding: 0, // No padding needed in ID32 box
-    unsynch: false,
-    unsupported: false,
-    encoding: defaultEncoding,
-    ...options.id3v2
-  }
-
-  id3v2Options.encodingIndex = encoding2Index(id3v2Options.encoding)
+  // No padding needed inside the ID32 box
+  const id3Data = encodeID3v2(tags, options)
 
   const mp4Options = {
     language: 'und',
     ...options.mp4
   }
-
-  // Validate tags
-  if (options.strict !== false) {
-    ID3v2.validate(tags.v2, options.strict, id3v2Options)
-  }
-
-  // Encode ID3v2 data
-  const id3Data = ID3v2.encode(tags.v2, id3v2Options)
 
   // Build ID32 box
   const id32Box = buildID32Box(id3Data, mp4Options.language)

--- a/src/utils/container.mjs
+++ b/src/utils/container.mjs
@@ -1,0 +1,32 @@
+
+import * as ID3v2 from '../id3v2/index.mjs'
+import { encoding2Index } from './strings.mjs'
+
+/**
+ * Build the ID3v2 options, validate, and encode the v2 tags into bytes.
+ * Shared by the container/stream format encoders (MP4, AIFF, AAC) which only
+ * differ in their default padding/unsynch values.
+ * @param {object} tags - Tags object with `v2`/`v2Details`
+ * @param {object} options - Write options ({ strict, id3v2 })
+ * @param {object} [defaults] - Format-specific id3v2 defaults (e.g. padding)
+ * @returns {Uint8Array} Encoded ID3v2 bytes
+ */
+export function encodeID3v2 (tags, options, defaults = {}) {
+  const id3v2Options = {
+    version: tags.v2Details ? tags.v2Details.version[0] : 3,
+    padding: 0,
+    unsynch: false,
+    unsupported: false,
+    encoding: 'utf-8',
+    ...defaults,
+    ...options.id3v2
+  }
+
+  id3v2Options.encodingIndex = encoding2Index(id3v2Options.encoding)
+
+  if (options.strict !== false) {
+    ID3v2.validate(tags.v2, options.strict, id3v2Options)
+  }
+
+  return new Uint8Array(ID3v2.encode(tags.v2, id3v2Options))
+}


### PR DESCRIPTION
## Summary

Pure-refactor follow-up to #654. The multi-format (MP4/AIFF/AAC) support works, but carried a lot of duplication and some dead code. This collapses it with **no behavior change** — all 68 tests pass unmodified.

Net **−499 lines** of source.

## What changed

### `src/mp3tag.mjs` — the bulk of it
- `readBuffer` duplicated the ~95-line convenience-property descriptor block (`title`/`artist`/`album`/…) **once per format**, even though the shared block at the end of the method already handles every format. The three format branches also `return tags` early to bypass it.
- Introduced one module-level `CONTAINERS` table describing AIFF/MP4/AAC uniformly. `readBuffer` now detects a container in a single loop and **falls through** to the existing shared `Object.defineProperties` block instead of re-declaring it (container tags have no `v1`, so the `v1` fallbacks are harmless no-ops).
- `writeBuffer` and `getAudioBuffer` iterate the same table instead of three copy-pasted branches each.

### `src/utils/container.mjs` (new)
- Extracted the identical "build id3v2 options → set encodingIndex → validate → encode" preamble that the three format encoders repeated, differing only in default `padding`/`unsynch`.

### Dead code removed
- `parseID32Box` (exported, never called) and `getMP4WithoutID32` (exported, never called).
- The discarded `hdlrData` `BufferView` in `buildMetaStructure` — built and never used; the function now reuses `buildMetaWithID32`.
- The per-module `validate()` exports (MP4/AIFF/AAC) — never imported anywhere; each encoder calls `ID3v2.validate` directly.

## Not included (deliberately)

Three things I noticed but left alone because they're **behavioral** decisions, not cleanups — happy to split into separate issues/PRs:
- The container encoders validate when `strict` is `undefined` (`strict !== false`), so writing to MP4/AIFF/AAC validates by default while writing MP3 does not.
- `save()` detects containers unconditionally and ignores the `mp4`/`aiff`/`aac: false` read toggles.
- The `viewer.mjs` `byteOffset` change from #654 touches the shared `BufferView` base class (correct fix, broad blast radius).

## Verification
- `npm run lint` (standard): clean
- `npm run build` (rollup): succeeds
- `npm test` (mocha): **68/68 passing**, suite unchanged
